### PR TITLE
not only the largest connected component should be used

### DIFF
--- a/src/calculations.jl
+++ b/src/calculations.jl
@@ -283,6 +283,7 @@ function shortest_path_distance(from::Candidate, to::Candidate, city_map)
     # distance from end of from to begin of to
     len_way_from = total_length(from.way)
     sp = shortest_candidate_path(from, to, city_map)
+    isnothing(sp) && return Inf
     sp_from_e_to_b = total_length(city_map, sp)
 
     return  len_way_from - from.λ + sp_from_e_to_b + to.λ
@@ -577,13 +578,21 @@ function calculate_streetpath(name, subpath_id, candidates, city_map)
             end
         else
             sp = shortest_candidate_path(current_candidate, next_candidate, city_map)
+            if isnothing(sp)
+                if !isempty(segments)
+                    push!(streetpaths, StreetPath(name, subpath_id, segments))
+                    subpath_id += 1
+                    segments = Vector{StreetSegment}()
+                end
+                continue
+            end
             partial_segments = get_segments(city_map, current_candidate, next_candidate, sp)
             len_shortest_path =  total_length(city_map, sp)u"m"
             start_time = current_candidate.measured_point.time
             finish_time = next_candidate.measured_point.time
             duration = Quantity(finish_time - start_time)
             speed = uconvert(u"km/hr", len_shortest_path/duration)
-            if speed > 20u"km/hr"
+            if speed > 20u"km/hr" && !isempty(segments)
                 push!(streetpaths, StreetPath(name, subpath_id, segments))
                 subpath_id += 1
                 segments = Vector{StreetSegment}()

--- a/src/calculations.jl
+++ b/src/calculations.jl
@@ -429,7 +429,7 @@ function get_local_map(city_map, gps_points, map_local_path, padding=200)
         push!(node_transformed_points, transformed_point)
     end
     _, dists = nn(kd_tree, node_transformed_points)
-    node_ids = findall(<=(500), dists)
+    node_ids = findall(<=(padding), dists)
     create_local_json(city_map, node_ids, map_local_path)
 
     return parse_map(map_local_path)
@@ -438,6 +438,13 @@ end
 function map_matching(fpath, city_map::AbstractSimpleMap, walked_parts::WalkedParts, map_local_path="tmp_local_map.json")
     name = basename(fpath)
     gps_points = get_gps_points(fpath)
+    return map_matching(gps_points, city_map, walked_parts, map_local_path; name)
+end
+
+function map_matching(gps_points::Vector{GPSPoint}, city_map::AbstractSimpleMap, walked_parts::WalkedParts, map_local_path="tmp_local_map.json"; name=nothing)
+    if isnothing(name)
+        name = Dates.format(now(), "yyyy-mm-dd_HH:MM:SS")
+    end
     map_local = get_local_map(city_map, gps_points, map_local_path)
     if isempty(map_local.ways)
         return (walked_parts = walked_parts, added_kms = 0.0, this_walked_road_km = 0.0)     

--- a/src/shortest_path.jl
+++ b/src/shortest_path.jl
@@ -91,6 +91,8 @@ function get_shortest_path(city_map::Map, sp_from_id, sp_to_id)
     graph_to_id = osmgraph.node_to_index[sp_to_id]
     
     edges = get_shortest_path(city_map.bounded_shortest_paths, graph_from_id, graph_to_id)
+    # if there is no path at all
+    isempty(edges) && return nothing
     osm_vertices = Vector{Int}()
     for e in edges
         push!(osm_vertices, osmgraph.index_to_node[src(e)])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -125,7 +125,7 @@ Return a [`Map`](@ref) object from the given json file path that was created usi
 function parse_map(fpath, geojson_path=nothing)
     json, no_graph_map = parse_no_graph_map(fpath, geojson_path)
     json_string = convert_keys_recursive(json)
-    graph = graph_from_object(json_string; weight_type=:distance, network_type=:all)
+    graph = graph_from_object(json_string; weight_type=:distance, network_type=:all, largest_connected_component=false)
     bounded_shortest_paths = bounded_all_shortest_paths(graph, 0.25, no_graph_map.osm_id_to_node_id, no_graph_map.walkable_road_nodes)
     return Map(no_graph_map, graph, bounded_shortest_paths)
 end


### PR DESCRIPTION
If a path goes out of the city and in again for example it can be the case that there is no actual path inside the city that was downloaded that connects the two.

Previously only the largest connected component was saved and shortest path computation failed before.