### PR TITLE
StreetSegment assert test and bugfix correct way orientation

### DIFF
--- a/src/calculations.jl
+++ b/src/calculations.jl
@@ -374,6 +374,7 @@ function create_local_json(city_map, node_ids_start, fpath)
         element[:type] = "way"
         element[:nodes] = [node.id for node in way.nodes]
         element[:tags] = Dict{Symbol, String}()
+        element[:tags][:name] = way.name
         element[:tags][:highway] = way.highway
         element[:tags][:foot] = way.foot
         element[:tags][:access] = way.access
@@ -612,7 +613,7 @@ function get_segments(city_map, current_candidate, next_candidate, sp)
         nodeid = get_prev_node_id(next_candidate)
         node = get_node(city_map, nodeid)
         gps_point = GPSPoint(LLA(node.lat, node.lon), current_candidate.measured_point.time)
-        c2 = get_candidate_on_way(city_map, gps_point, next_candidate.way, trans, rev_trans; rev=current_candidate.way_is_reverse)
+        c2 = get_candidate_on_way(city_map, gps_point, next_candidate.way, trans, rev_trans; rev=next_candidate.way_is_reverse)
         push!(segments, StreetSegment(c2, next_candidate))
         return segments
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -79,6 +79,11 @@ They are both on the same way and have the same direction.
 struct StreetSegment
     from::Candidate
     to::Candidate
+    function StreetSegment(from, to)
+        @assert from.way.id == to.way.id
+        @assert from.way_is_reverse == to.way_is_reverse
+        new(from, to)
+    end
 end
 
 struct StreetPath


### PR DESCRIPTION
Small bugfix which resulted in missing parts when one streetsegment candidate was reversed. 
This is impossible now due to asserts and a bugfix in get segments the bug itself got fixed.
Potentially one could make the reversing inside the constructor. :thinking: 