### PR TITLE
bugfix district section counted multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+### Bugfixes
+- District kms are calculated more correctly
+    - Still a section can be counted to two districts if one node is inside one and the next inside another district
+
 ## v0.1.1 (28th of November 2024)
 ### Bugfixes: 
 - shortest path contained non walkable roads but walkable roads were feasible 

--- a/src/districts.jl
+++ b/src/districts.jl
@@ -226,10 +226,6 @@ function get_walked_district_perc(city_map::AbstractSimpleMap, walked_ways::Vect
     district_kms = get_district_kms(city_map)
     district_perc = OrderedDict{Symbol, Float64}()
     for district in keys(district_kms)
-        if district == :Cranz
-            @show district_kms[district]
-            @show walked_district_kms[district]
-        end
         if !haskey(walked_district_kms, district)
             district_perc[district] = 0.0
             continue 


### PR DESCRIPTION
It was possible before that some parts were counted multiple times when computing the district kms because I considered the previous node instead of calculating the distance between the walked way start and the next node. (Same for the end)
